### PR TITLE
Fixed resample crashing due to extraneous deletes

### DIFF
--- a/dsp/include/const.h
+++ b/dsp/include/const.h
@@ -4,7 +4,7 @@
 namespace consts {
 
 const int SAMPLE_RATE = 48000;
-const int BLOCK_SIZE = 512;
+const int BLOCK_SIZE = 1024;
 const int AUDIO_OUTS = 2;
 const int DEVICE_NUM = -1;
 enum streamType {synchronous, asynchronous, sequenced, derived};

--- a/dsp/include/utility.h
+++ b/dsp/include/utility.h
@@ -1,11 +1,11 @@
 #ifndef UTILITY_H
 #define UTILITY_H
 
-#include <cmath>
-#include <memory>
 #include "Gamma/Gamma.h"
 #include "al/io/al_File.hpp"
 #include "const.h"
+#include <cmath>
+#include <memory>
 
 namespace util {
 
@@ -13,104 +13,104 @@ namespace util {
  * Line class that moves from one point to another over a set period of time.
  */
 class line {
-   public:
-    /**
-     * @brief Default constructor.
-     */
-    line() { mSamplingRate = consts::SAMPLE_RATE; }
+public:
+  /**
+   * @brief Default constructor.
+   */
+  line() { mSamplingRate = consts::SAMPLE_RATE; }
 
-    /**
-     * @brief line constructor.
-     *
-     * @param[in] The sample rate needed for operator()
-     */
-    line(float samplingRate) : mSamplingRate(samplingRate) {}
+  /**
+   * @brief line constructor.
+   *
+   * @param[in] The sample rate needed for operator()
+   */
+  line(float samplingRate) : mSamplingRate(samplingRate) {}
 
-    /**
-     * @brief Generate line in real-time.
-     *
-     * @return Amplitude value at a point in time.
-     */
-    float operator()();
+  /**
+   * @brief Generate line in real-time.
+   *
+   * @return Amplitude value at a point in time.
+   */
+  float operator()();
 
-    /**
-     * @brief Set paramaters of class.
-     *
-     * @param[in]: Starting value.
-     * @param[in]: Target value.
-     * @param[in]: The amount of time to go from the starting value to the target
-     * value.
-     */
-    void set(float v = 0, float t = 0, float s = 1);
+  /**
+   * @brief Set paramaters of class.
+   *
+   * @param[in]: Starting value.
+   * @param[in]: Target value.
+   * @param[in]: The amount of time to go from the starting value to the target
+   * value.
+   */
+  void set(float v = 0, float t = 0, float s = 1);
 
-    void setSamplingRate(float samplingRate) { mSamplingRate = samplingRate; }
+  void setSamplingRate(float samplingRate) { mSamplingRate = samplingRate; }
 
-    float getSamplingRate() const { return mSamplingRate; }
+  float getSamplingRate() const { return mSamplingRate; }
 
-    /**
-     * @brief Check if the line function is complete.
-     *
-     * @param[in] Return true if reached target, false otherwise.
-     */
-    bool const done() { return value == target; }
+  /**
+   * @brief Check if the line function is complete.
+   *
+   * @param[in] Return true if reached target, false otherwise.
+   */
+  bool const done() { return value == target; }
 
-   private:
-    float value = 0, target = 0, seconds = 1, increment = 0;
-    float mSamplingRate;
+private:
+  float value = 0, target = 0, seconds = 1, increment = 0;
+  float mSamplingRate;
 };
 
 /**
  * Envelope generator for creating exponetial decay and exponential growth.
  */
 class expo {
-   public:
-    /**
-     * @brief Generate exponential envelope in real-time.
-     *
-     * @return Amplitude value at a point in time.
-     */
-    float operator()();
+public:
+  /**
+   * @brief Generate exponential envelope in real-time.
+   *
+   * @return Amplitude value at a point in time.
+   */
+  float operator()();
 
-    /**
-     * @brief Getter and setter for sampling rate of envelope.
-     */
-    void setSamplingRate(float samplingRate) { mSamplingRate = samplingRate; }
-    float getSamplingRate() const { return mSamplingRate; }
+  /**
+   * @brief Getter and setter for sampling rate of envelope.
+   */
+  void setSamplingRate(float samplingRate) { mSamplingRate = samplingRate; }
+  float getSamplingRate() const { return mSamplingRate; }
 
-    /**
-     * @brief Used to set values to its original position.
-     */
-    void set();
+  /**
+   * @brief Used to set values to its original position.
+   */
+  void set();
 
-    /**
-     * Set parameters of envelope.
-     *
-     * @param[in] The duration of the envelope in seconds.
-     * @param[in] If true, the envelope is reversed and becomes an exponential
-     * growth envelope.
-     * @param[in] Sets the amplitude threshold for when to release the envelope.
-     */
-    void set(float seconds, bool reverse, float threshold);
-    void set(float seconds, bool reverse);
-    void set(float seconds);
+  /**
+   * Set parameters of envelope.
+   *
+   * @param[in] The duration of the envelope in seconds.
+   * @param[in] If true, the envelope is reversed and becomes an exponential
+   * growth envelope.
+   * @param[in] Sets the amplitude threshold for when to release the envelope.
+   */
+  void set(float seconds, bool reverse, float threshold);
+  void set(float seconds, bool reverse);
+  void set(float seconds);
 
-    /**
-     * @brief Check if the line function is complete.
-     *
-     * @param[in] Return true if reached target, false otherwise.
-     */
-    bool done() const { return mX == 0; }
+  /**
+   * @brief Check if the line function is complete.
+   *
+   * @param[in] Return true if reached target, false otherwise.
+   */
+  bool done() const { return mX == 0; }
 
-    /**
-     * @brief Increment in the time axis/
-     */
-    void increment() { mX += mIncrementX; }
+  /**
+   * @brief Increment in the time axis/
+   */
+  void increment() { mX += mIncrementX; }
 
-   private:
-    float mIncrementX, mX = 0, mY = 0.001, mThresholdX = -1 * std::log(0.001), mThresholdY = 0.001,
-                       mSamplingRate = consts::SAMPLE_RATE;
-    bool mReverse = 0;
-    int mTotalS = 1;
+private:
+  float mIncrementX, mX = 0, mY = 0.001, mThresholdX = -1 * std::log(0.001),
+                     mThresholdY = 0.001, mSamplingRate = consts::SAMPLE_RATE;
+  bool mReverse = 0;
+  int mTotalS = 1;
 };
 
 /**
@@ -118,133 +118,138 @@ class expo {
  * A tukey window is like a fatter Hann envelope.
  */
 class tukey {
-   public:
-    /**
-     * @brief Generate tukey envelope in real-time.
-     *
-     * @return Amplitude value at a point in time.
-     */
-    float operator()();
+public:
+  /**
+   * @brief Generate tukey envelope in real-time.
+   *
+   * @return Amplitude value at a point in time.
+   */
+  float operator()();
 
-    /**
-     * @brief Getter and setter for sampling rate of envelope.
-     */
-    void setSamplingRate(float samplingRate) { mSamplingRate = samplingRate; }
-    float getSamplingRate() const { return mSamplingRate; }
+  /**
+   * @brief Getter and setter for sampling rate of envelope.
+   */
+  void setSamplingRate(float samplingRate) { mSamplingRate = samplingRate; }
+  float getSamplingRate() const { return mSamplingRate; }
 
-    /**
-     * Used to reset values to original position.
-     */
-    void set();
+  /**
+   * Used to reset values to original position.
+   */
+  void set();
 
-    /**
-     * Set parameters of envelope.
-     *
-     * @param[in] The duration of the envelope in seconds.
-     * @param[in] FROM 0 to 1. A coefficient that determines the ratio of the
-     * sustain to the attack and release. 0 being a rectangular envelope and 1
-     * being a Hann envelope.
-     *  https://www.mathworks.com/help/signal/ref/tukeywin.html
-     */
+  /**
+   * Set parameters of envelope.
+   *
+   * @param[in] The duration of the envelope in seconds.
+   * @param[in] FROM 0 to 1. A coefficient that determines the ratio of the
+   * sustain to the attack and release. 0 being a rectangular envelope and 1
+   * being a Hann envelope.
+   *  https://www.mathworks.com/help/signal/ref/tukeywin.html
+   */
 
-    void set(float seconds, float alpha);
-    void set(float seconds);
+  void set(float seconds, float alpha);
+  void set(float seconds);
 
-    /**
-     * @brief Check if the line function is complete.
-     *
-     * @param[in] Return true if reached target, false otherwise.
-     */
-    bool done() const { return totalS == currentS; }
+  /**
+   * @brief Check if the line function is complete.
+   *
+   * @param[in] Return true if reached target, false otherwise.
+   */
+  bool done() const { return totalS == currentS; }
 
-    /**
-     * @brief Increment in the time axis/
-     */
-    void increment() { currentS++; }
+  /**
+   * @brief Increment in the time axis/
+   */
+  void increment() { currentS++; }
 
-   private:
-    float value = 0, alpha = 0.6, mSamplingRate = consts::SAMPLE_RATE;
-    int currentS = 0, totalS = 1;
+private:
+  float value = 0, alpha = 0.6, mSamplingRate = consts::SAMPLE_RATE;
+  int currentS = 0, totalS = 1;
 };
 
 /**
  * A Buffer struct that has multi-sound file loading functionalities.
  * Inspired by Karl Yerkes.
  */
-template <typename T>
-class buffer {
-   public:
-    T *data;
-    unsigned size = 0;
-    int channels;
-    std::string filePath;
+template <typename T> class buffer {
+public:
+  T *data;
+  unsigned size = 0;
+  int channels;
+  std::string filePath;
 
-    virtual ~buffer() {
-        fflush(stdout);
-        if (data) delete[] data;
+  virtual ~buffer() {
+    fflush(stdout);
+    if (data)
+      delete[] data;
+  }
+
+  void deleteBuffer() {
+    fflush(stdout);
+    if (data)
+      delete[] data;
+  }
+
+  T &operator[](unsigned index) { return data[index]; }
+  T operator[](const T index) const { return get(index); }
+
+  /**
+   * @brief Resize buffer.
+   *
+   * @param[in] New size.
+   */
+  void resize(unsigned n) {
+    size = n;
+    if (data)
+      delete[] data; // or your have a memory leak
+    if (n == 0) {
+      data = nullptr;
+    } else {
+      data = new T[n];
+      for (unsigned i = 0; i < n; ++i)
+        data[i] = 0.0f;
     }
+  }
 
-    void deleteBuffer() {
-        fflush(stdout);
-        if (data) delete[] data;
-    }
+  /**
+   * @brief Index buffer.
+   *
+   * @param[in] Index in buffer where value desired is stored.
+   *
+   * @return Value at given index.
+   */
+  T get(float index) const {
+    if (index < 0)
+      index += size;
+    if (index > size)
+      index -= size;
 
-    T &operator[](unsigned index) { return data[index]; }
-    T operator[](const T index) const { return get(index); }
+    return raw(index);
+  }
 
-    /**
-     * @brief Resize buffer.
-     *
-     * @param[in] New size.
-     */
-    void resize(unsigned n) {
-        size = n;
-        if (data) delete[] data;  // or your have a memory leak
-        if (n == 0) {
-            data = nullptr;
-        } else {
-            data = new T[n];
-            for (unsigned i = 0; i < n; ++i) data[i] = 0.0f;
-        }
-    }
+  T raw(const float index) const {
+    const unsigned i = floor(index);
+    const T x0 = data[i];
+    const T x1 = data[(i == (size - 1)) ? 0 : i + 1]; // looping semantics
+    const T t = index - i;
+    return x1 * t + x0 * (1 - t);
+  }
 
-    /**
-     * @brief Index buffer.
-     *
-     * @param[in] Index in buffer where value desired is stored.
-     *
-     * @return Value at given index.
-     */
-    T get(float index) const {
-        if (index < 0) index += size;
-        if (index > size) index -= size;
-
-        return raw(index);
-    }
-
-    T raw(const float index) const {
-        const unsigned i = floor(index);
-        const T x0 = data[i];
-        const T x1 = data[(i == (size - 1)) ? 0 : i + 1];  // looping semantics
-        const T t = index - i;
-        return x1 * t + x0 * (1 - t);
-    }
-
-    /**
-     * @brief Add value to index in buffer.
-     *
-     * @param[in] Index of buffer where value will be stored.
-     * @param[in] Value to be stored.
-     *
-     * @return Value at given index.
-     */
-    void add(const float index, const T value) {
-        const unsigned i = floor(index);
-        const unsigned j = (i == (size - 1)) ? 0 : i + 1;  // looping semantics
-        const float t = index - i;
-        data[i] += value * (1 - t);
-        data[j] += value * t;
-    }
+  /**
+   * @brief Add value to index in buffer.
+   *
+   * @param[in] Index of buffer where value will be stored.
+   * @param[in] Value to be stored.
+   *
+   * @return Value at given index.
+   */
+  void add(const float index, const T value) {
+    const unsigned i = floor(index);
+    const unsigned j = (i == (size - 1)) ? 0 : i + 1; // looping semantics
+    const float t = index - i;
+    data[i] += value * (1 - t);
+    data[j] += value * t;
+  }
 };
 
 /**
@@ -253,7 +258,8 @@ class buffer {
  * @param[in] The filename. An absolute filename is preferred.
  * @param[out] A vector holding the audio buffers.
  */
-bool load(std::string fileName, std::vector<std::shared_ptr<buffer<float>>> &buf,
+bool load(std::string fileName,
+          std::vector<std::shared_ptr<buffer<float>>> &buf,
           float sampleRate = consts::SAMPLE_RATE, bool resample = 1);
 
 /**
@@ -266,6 +272,6 @@ std::string getExecutablePath();
  */
 bool compareFileNoCase(al::FilePath s1, al::FilePath s2);
 
-}  // namespace util
+} // namespace util
 
 #endif

--- a/dsp/src/ecSynth.cpp
+++ b/dsp/src/ecSynth.cpp
@@ -283,9 +283,6 @@ std::string ecSynth::loadInitSoundFiles() {
 }
 
 void ecSynth::clearSoundFiles() {
-  for (auto i = soundClip.begin(); i != soundClip.end(); i++) {
-    (*i)->deleteBuffer();
-  }
   soundClip.clear();
 
   mClipNum = 0;

--- a/dsp/src/utility.cpp
+++ b/dsp/src/utility.cpp
@@ -168,7 +168,7 @@ bool util::load(std::string fileName,
     return 0;
   }
 
-  std::shared_ptr<buffer<float>> a (new buffer<float>());
+  std::shared_ptr<buffer<float>> a(new buffer<float>());
   a->filePath = fileName;
   a->size = soundFile.samples();
   a->data = new float[a->size];
@@ -183,7 +183,7 @@ bool util::load(std::string fileName,
      * Comment out if you want to read arbitrary files.
      */
     if (soundFile.frameRate() != samplingRate) {
-      std::shared_ptr<buffer<float>> b (new buffer<float>());
+      std::shared_ptr<buffer<float>> b(new buffer<float>());
       b->filePath = fileName;
       b->size = (a->size) / soundFile.frameRate() * samplingRate;
       b->data = new float[b->size];


### PR DESCRIPTION
- The vector that stores audio buffers now using smart pointers to buffers. 
- I forgot that I do not need to manually delete each buffer now when resampling. EASY FIX