### PR TITLE
feat(UI): Add Mouse Dragging in Waveform Histogram

### DIFF
--- a/ecSource/src/ecInterface.cpp
+++ b/ecSource/src/ecInterface.cpp
@@ -1657,6 +1657,13 @@ void ecInterface::onDraw(Graphics &g) {
                           int(scanWidth * 100));
       ImGui::PopStyleVar();
 
+      // Move scanHead to mouse position if Histogram is clicked
+      if (ImGui::IsItemHovered() && ImGui::IsMouseDown(0)) {
+          float relativeMousePosX = (ImGui::GetMousePos()[0] - displayPosX) / plotWidth;
+          scanHead = relativeMousePosX;
+          granulator.ECParameters[consts::SCAN_BEGIN]->setParam(scanHead);
+      }
+
       ImDrawList *drawList = ImGui::GetWindowDrawList();
 
       // Draw Scan Width


### PR DESCRIPTION
The scan head can be positioned by clicking/dragging on the waveform histogram

For me this makes moving the scan head more intuitive and easier to move to the correct position.